### PR TITLE
Fix infinite recursion on self-referencing FK with follow_nested

### DIFF
--- a/elasticmapper/mapper.py
+++ b/elasticmapper/mapper.py
@@ -26,6 +26,7 @@ class Mapper:
         exclude: Collection[Optional[str]] = (),
         follow_nested: bool = False,
         custom_values: Optional[Dict[str, dict]] = None,
+        _visited: Optional[set] = None,
     ):
         self.model = model
         self.keyword_fields = keyword_fields
@@ -35,7 +36,12 @@ class Mapper:
         self.follow_nested = follow_nested
         self.custom_values = custom_values
         self.orm_mapping = self._orm_fields_mapping.get(self.orm)
+        self._visited = set(_visited) if _visited else set()
+        self._visited.add(self._model_key(model))
         self.schema = self._get_model_columns()
+
+    def _model_key(self, model):
+        return id(model)
 
     def load(self):
         self._fill_schema()
@@ -102,12 +108,13 @@ class DjangoMapper(Mapper):
 
     def _process_foreign_keys(self, column_name):
         foreign_model = self.model._meta.get_field(column_name).target_field.model
-        if not self.follow_nested:
+        if not self.follow_nested or self._model_key(foreign_model) in self._visited:
             return self.orm_mapping.get(foreign_model._meta.local_fields[0].get_internal_type())
         else:
             return {
                 'properties': self.__class__(
                     model=foreign_model,
+                    _visited=self._visited,
                 ).load(),
             }
 
@@ -120,6 +127,9 @@ class DjangoMapper(Mapper):
 
 class SQLAlchemyMapper(Mapper):
     orm = SupportedORMs.SQLAlchemy
+
+    def _model_key(self, model):
+        return id(getattr(model, '__table__', model))
 
     def _get_model_columns(self):
         columns = {}
@@ -136,12 +146,13 @@ class SQLAlchemyMapper(Mapper):
     def _process_foreign_keys(self, column_name):
         column = self.model.__table__.columns.get(column_name)
         foreign_model = next(iter(column.foreign_keys)).column.table
-        if not self.follow_nested:
+        if not self.follow_nested or self._model_key(foreign_model) in self._visited:
             return self.orm_mapping.get(foreign_model.columns[0].type.__class__.__visit_name__)
         else:
             return {
                 'properties': self.__class__(
                     model=foreign_model,
+                    _visited=self._visited,
                 ).load(),
             }
 
@@ -168,12 +179,13 @@ class PeeweeMapper(Mapper):
 
     def _process_foreign_keys(self, column_name):
         foreign_model = self.model._meta.columns.get(column_name).rel_model
-        if not self.follow_nested:
+        if not self.follow_nested or self._model_key(foreign_model) in self._visited:
             return self.orm_mapping.get(self.model._meta.columns.get(column_name).rel_field)
         else:
             return {
                 'properties': self.__class__(
                     model=foreign_model,
+                    _visited=self._visited,
                 ).load(),
             }
 

--- a/tests/test_django_orm.py
+++ b/tests/test_django_orm.py
@@ -34,6 +34,11 @@ class Post(models.Model):
     author = models.ForeignKey(User, on_delete=models.CASCADE, related_name='posts')
 
 
+class Category(models.Model):
+    name = models.CharField(max_length=30)
+    parent = models.ForeignKey('self', null=True, on_delete=models.CASCADE)
+
+
 class Tag(models.Model):
     id = models.UUIDField(
         primary_key=True,
@@ -78,6 +83,13 @@ def test_django_fk_mapping(follow_nested, excepted_result):
     ).load()
     for item in excepted_result:
         assert item in post_elastic_mapping['author']
+
+
+def test_django_self_join_mapping():
+    flat = DjangoMapper(model=Category, follow_nested=False).load()
+    nested = DjangoMapper(model=Category, follow_nested=True).load()
+    assert flat == nested
+    assert nested['parent'] == {'type': 'integer'}
 
 
 @pytest.mark.skip("no m2m support")

--- a/tests/test_peewee_orm.py
+++ b/tests/test_peewee_orm.py
@@ -33,6 +33,11 @@ class Post(BaseModel):
     author = ForeignKeyField(User, on_delete='CASCADE')
 
 
+class Category(BaseModel):
+    name = CharField()
+    parent = ForeignKeyField('self', null=True)
+
+
 def test_peewee_mapping():
     user_elastic_mapping = PeeweeMapper(
         model=User,
@@ -56,3 +61,10 @@ def test_peewee_fk_mapping(follow_nested, excepted_result):
     ).load()
     for field in excepted_result:
         assert field in post_elastic_mapping['author_id']
+
+
+def test_peewee_self_join_mapping():
+    flat = PeeweeMapper(model=Category, follow_nested=False).load()
+    nested = PeeweeMapper(model=Category, follow_nested=True).load()
+    assert flat == nested
+    assert 'properties' not in str(nested['parent_id'])

--- a/tests/test_sqlalchemy_orm.py
+++ b/tests/test_sqlalchemy_orm.py
@@ -29,6 +29,14 @@ class Post(Base):
     author = Column(Integer, ForeignKey('users.id'))
 
 
+class Category(Base):
+    __tablename__ = 'categories'
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    parent_id = Column(Integer, ForeignKey('categories.id'))
+
+
 def test_sqlalchemy_mapping():
     user_elastic_mapping = SQLAlchemyMapper(
         model=User,
@@ -54,3 +62,10 @@ def test_sqlalchemy_fk_mapping(follow_nested, excepted_result):
         follow_nested=follow_nested,
     ).load()
     assert post_elastic_mapping['author'] == excepted_result
+
+
+def test_sqlalchemy_self_join_mapping():
+    flat = SQLAlchemyMapper(model=Category, follow_nested=False).load()
+    nested = SQLAlchemyMapper(model=Category, follow_nested=True).load()
+    assert flat == nested
+    assert nested['parent_id'] == {'type': 'integer'}


### PR DESCRIPTION
Closes #23.

## Problem

When a model has a foreign key to itself (e.g. `Category.parent_id -> categories.id`), calling the mapper with `follow_nested=True` blows up:

- **SQLAlchemy** — infinite recursion ending in `AttributeError: 'Table' object has no attribute '__table__'`.
- **Peewee** / **Django** — recursion is silently swallowed deeper in the stack and produces malformed mappings such as `{'parent_id': {'type': None}}` or duplicate keys.

## Fix

Thread a private `_visited` set through recursive `Mapper` construction. On re-entry to a model already in `_visited`, fall back to the flat PK type — i.e. the same result as `follow_nested=False` for that edge, which is the only sensible terminator for a self-referencing FK without an explicit depth limit.

`SQLAlchemyMapper` overrides a small `_model_key` hook because its recursion passes a `Table` object rather than a Model class, so the identity used for the `_visited` set has to be the table.

## Tests

Added one self-join test per ORM. All assert the invariant `flat == nested` for a self-referencing model — `follow_nested=True` must collapse to the flat representation when the only nested edge is the cycle. SQLAlchemy/Django additionally check the resulting type is the PK type.

`pytest -v`: 12 passed, 1 skipped (pre-existing m2m skip).